### PR TITLE
Add charts and normative table excerpts to report

### DIFF
--- a/condensation/report.py
+++ b/condensation/report.py
@@ -1,8 +1,100 @@
-def report(results: dict) -> str:
-    """Generate a minimal HTML report from analysis results.
+"""Generate HTML reports with charts and normative table snippets."""
 
-    This is a starter implementation; charts and normative tables are TODO.
-    """
+from __future__ import annotations
+
+import base64
+from io import BytesIO
+from typing import Iterable, List, Tuple
+
+try:  # pragma: no cover - matplotlib is optional at runtime
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - gracefully degrade if missing
+    plt = None  # type: ignore
+
+try:  # pragma: no cover - tables are optional
+    from .tables import p_max_tabulated, theta_s_tabulated
+except Exception:  # pragma: no cover
+    p_max_tabulated = None  # type: ignore
+    theta_s_tabulated = None  # type: ignore
+
+
+def _encode_fig(fig) -> str:
+    buf = BytesIO()
+    fig.savefig(buf, format="png", bbox_inches="tight")
+    plt.close(fig)
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+def _plot_temperature(xs: Iterable[float], ys: Iterable[float]) -> str:
+    if plt is None:
+        return ""
+    fig, ax = plt.subplots()
+    ax.plot(list(xs), list(ys))
+    ax.set_xlabel("Σd [m]")
+    ax.set_ylabel("θ [°C]")
+    ax.set_title("Temperature profile")
+    return _encode_fig(fig)
+
+
+def _plot_vapor(xs: Iterable[float], p: Iterable[float], ps: Iterable[float]) -> str:
+    if plt is None:
+        return ""
+    fig, ax = plt.subplots()
+    ax.plot(list(xs), list(p), label="p")
+    ax.plot(list(xs), list(ps), label="p_sat")
+    ax.set_xlabel("Σ(μ·d) [m²·Pa·h/kg]")
+    ax.set_ylabel("p [Pa]")
+    ax.set_title("Vapor pressure profile")
+    ax.legend()
+    return _encode_fig(fig)
+
+
+def _tab21(theta_i: float | None, phi_i: float | None) -> str:
+    if theta_i is None or phi_i is None or theta_s_tabulated is None:
+        return "<p>Tab. 2.1 unavailable.</p>"
+    try:
+        theta_s = theta_s_tabulated(theta_i, phi_i)  # type: ignore[misc]
+    except Exception:
+        theta_s = None
+    if theta_s is None:
+        return "<p>Tab. 2.1 unavailable.</p>"
+    return (
+        "<table id='tab21'>"
+        "<tr><th>θi (°C)</th><th>φi (%)</th><th>θs (°C)</th></tr>"
+        f"<tr><td>{theta_i:.1f}</td><td>{phi_i:.0f}</td><td>{theta_s:.1f}</td></tr>"
+        "</table>"
+    )
+
+
+def _tab22(temps: Iterable[float]) -> str:
+    if p_max_tabulated is None:
+        return "<p>Tab. 2.2 unavailable.</p>"
+    rows: List[Tuple[float, float]] = []
+    for T in list(temps)[:5]:
+        try:
+            p = p_max_tabulated(T)  # type: ignore[misc]
+        except Exception:
+            p = None
+        if p is not None:
+            rows.append((T, float(p)))
+    if not rows:
+        return "<p>Tab. 2.2 unavailable.</p>"
+    trs = "".join(
+        f"<tr><td>{T:.1f}</td><td>{p:.0f}</td></tr>" for T, p in rows
+    )
+    return (
+        "<table id='tab22'>"
+        "<tr><th>T (°C)</th><th>p_sat (Pa)</th></tr>"
+        f"{trs}</table>"
+    )
+
+
+def report(results: dict) -> str:
+    """Generate an HTML report from analysis results with charts and table data."""
+
     surface = results.get("surface", {})
     zones = results.get("zones", [])
     lis = [
@@ -17,9 +109,30 @@ def report(results: dict) -> str:
         f"<li>Condensation zones: {zones}</li>",
         f"<li>Condensate proxy: {results.get('condensate_proxy', 0.0):.1f}</li>",
     ]
-    return "\n".join([
+
+    temp_chart = _plot_temperature(
+        results.get("thickness_axis", []), results.get("theta_profile", [])
+    )
+    vapor_chart = _plot_vapor(
+        results.get("vapor_axis", []),
+        results.get("p_line", []),
+        results.get("p_sat", []),
+    )
+
+    tab21_html = _tab21(results.get("theta_i"), results.get("phi_i"))
+    tab22_html = _tab22(results.get("theta_profile", []))
+
+    parts = [
         "<h2>Condensation Risk Report</h2>",
         "<ul>",
         *lis,
         "</ul>",
-    ])
+        "<h3>Charts</h3>",
+        f"<img src='data:image/png;base64,{temp_chart}' alt='Temperature chart' />" if temp_chart else "",
+        f"<img src='data:image/png;base64,{vapor_chart}' alt='Vapor chart' />" if vapor_chart else "",
+        "<h3>Tab. 2.1 excerpt</h3>",
+        tab21_html,
+        "<h3>Tab. 2.2 excerpt</h3>",
+        tab22_html,
+    ]
+    return "\n".join([p for p in parts if p])

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from condensation.dataclasses import Layer, Assembly, Climate
+from condensation.core import analyze
+from condensation import report as rpt
+
+def test_report_contains_charts_and_tables():
+    assembly = Assembly(layers=[Layer(name="Layer1", d=0.1, lambda_=0.04, mu=20, rho=800, xr_percent=5, xmax_percent=20)], Rsi=0.13, Rse=0.04)
+    climate = Climate(theta_i=20.0, phi_i=65.0, theta_e=5.0, phi_e=90.0)
+    results = analyze(assembly, climate)
+    results["theta_i"] = climate.theta_i
+    results["phi_i"] = climate.phi_i
+    html = rpt.report(results)
+    assert html.count("<img") >= 2
+    assert "id='tab21'" in html
+    assert "id='tab22'" in html
+    assert "data:image/png;base64" in html

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -117,6 +117,10 @@
         <canvas id="chartVapor"></canvas>
       </div>
     </div>
+    <div class="card" style="margin-top:16px">
+      <h3>Generated Report</h3>
+      <div id="report-html"></div>
+    </div>
     <div class="footer">Tip: Use material presets per layer, and adjust thickness sliders for quick what-if analysis.</div>
   </div>
 


### PR DESCRIPTION
## Summary
- render temperature and vapor-pressure charts in report using matplotlib
- show Tab. 2.1 and Tab. 2.2 data excerpts in the report
- expose generated report container in web UI and add integration test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afdf3b9838832ab12587687723a3db