### PR TITLE
Clean up final results UI and fix report syntax

### DIFF
--- a/condensation/report.py
+++ b/condensation/report.py
@@ -98,12 +98,12 @@ def report(results: dict) -> str:
     surface = results.get("surface", {})
     zones = results.get("zones", [])
     lis = [
-        f"<li>U-value: {results.get(''U'', float(''nan'')):.4f} W/m²·K</li>",
-        f"<li>ΣR: {results.get(''R_total'', float(''nan'')):.4f} m²·K/W</li>",
-        f"<li>q: {results.get(''q'', float(''nan'')):.3f} W/m²</li>",
-        f"<li>Surface: {''OK'' if not surface.get(''risk'') else ''Fail''} (θsi={surface.get(''theta_si'', float(''nan'')):.2f}°C vs θs={surface.get(''theta_s'', float(''nan'')):.2f}°C)</li>",
-        f"<li>pᵢ={results.get(''p_i'', float(''nan'')):.0f} Pa, pₑ={results.get(''p_e'', float(''nan'')):.0f} Pa</li>",
-        f"<li>Condensation: {''Yes'' if zones else ''No''}</li>",
+        f"<li>U-value: {results.get('U', float('nan')):.4f} W/m²·K</li>",
+        f"<li>ΣR: {results.get('R_total', float('nan')):.4f} m²·K/W</li>",
+        f"<li>q: {results.get('q', float('nan')):.3f} W/m²</li>",
+        f"<li>Surface: {'OK' if not surface.get('risk') else 'Fail'} (θsi={surface.get('theta_si', float('nan')):.2f}°C vs θs={surface.get('theta_s', float('nan')):.2f}°C)</li>",
+        f"<li>pᵢ={results.get('p_i', float('nan')):.0f} Pa, pₑ={results.get('p_e', float('nan')):.0f} Pa</li>",
+        f"<li>Condensation: {'Yes' if zones else 'No'}</li>",
     ]
 
     temp_chart = _plot_temperature(

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -13,8 +13,6 @@ input,select{width:100%;padding:8px;border-radius:8px;border:1px solid #374151;b
 .actions{display:flex;gap:8px;flex-wrap:wrap}
 .charts{display:grid;grid-template-columns:1fr 1fr;gap:16px}
 canvas{width:100%;height:300px;background:#0b1220;border:1px solid #374151;border-radius:8px}
-.result{font-family:ui-monospace, SFMono-Regular, Menlo, monospace;white-space:pre-wrap}
-.result#results{font-family:inherit;white-space:normal}
 .footer{opacity:.7;margin-top:12px;font-size:12px}
 
 /* Result presentation enhancements */

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -21,7 +21,6 @@
       .actions{display:flex;gap:8px;flex-wrap:wrap}
       .charts{display:grid;grid-template-columns:1fr 1fr;gap:16px}
       canvas{width:100%;height:300px;background:#0b1220;border:1px solid #374151;border-radius:8px}
-      .result{font-family:ui-monospace, SFMono-Regular, Menlo, monospace;white-space:pre-wrap}
       .footer{opacity:.7;margin-top:12px;font-size:12px}
     </style>
     <script defer src="{{ url_for('static', filename='app.js') }}"></script>
@@ -99,11 +98,11 @@
     <div class="grid" style="margin-top:16px">
       <div class="card">
         <h3>Results</h3>
-        <div id="results" class="result">Fill layers and click Calculate.</div>
+        <div id="results">Fill layers and click Calculate.</div>
       </div>
       <div class="card">
         <h3>Condensation Zones</h3>
-        <div id="zones" class="result">—</div>
+        <div id="zones">—</div>
       </div>
     </div>
 
@@ -129,165 +128,6 @@
     <div class="footer">Tip: Use material presets per layer, and adjust thickness sliders for quick what-if analysis.</div>
   </div>
 
-  <script>
-    // If static/app.js failed to load, provide minimal inline fallback
-    if (!window.__appLoaded) {
-      const layersDiv = document.getElementById('layers');
-      let materials = [];
-      const makeLayerEl = (idx) => {
-        const d = document.createElement('div');
-        d.className = 'row';
-        d.innerHTML = `
-          <div>
-            <label>Material</label>
-            <select data-idx="${idx}" class="matSelect"><option value="">—</option></select>
-            <label>Name</label>
-            <input type="text" class="name" value="Layer ${idx+1}">
-          </div>
-          <div>
-            <label>Thickness (m)</label>
-            <input type="number" step="0.001" class="d" value="0.100">
-            <input type="range" min="0.005" max="0.500" step="0.001" value="0.100" class="dSlider">
-          </div>
-          <div>
-            <label>λ (W/mK)</label>
-            <input type="number" step="0.001" class="lambda" value="0.040">
-          </div>
-          <div>
-            <label>μ (-)</label>
-            <input type="number" step="1" class="mu" value="20">
-          </div>
-          <div>
-            <label>ρ (kg/m³)</label>
-            <input type="number" step="1" class="rho" value="800">
-          </div>
-          <div>
-            <label>xr (%)</label>
-            <input type="number" step="0.1" class="xr" value="5">
-          </div>
-          <div>
-            <label>xmax (%)</label>
-            <input type="number" step="0.1" class="xmax" value="20">
-          </div>`;
-        // sync slider
-        const dInput = d.querySelector('.d');
-        const dSlider = d.querySelector('.dSlider');
-        dSlider.addEventListener('input', () => { dInput.value = (+dSlider.value).toFixed(3); });
-        dInput.addEventListener('input', () => { dSlider.value = dInput.value; });
-        // material select
-        const sel = d.querySelector('.matSelect');
-        sel.addEventListener('change', () => {
-          const m = materials.find(mm => mm.name === sel.value);
-          if (m) {
-            d.querySelector('.lambda').value = m.lambda_;
-            d.querySelector('.mu').value = m.mu;
-            d.querySelector('.rho').value = m.rho;
-            d.querySelector('.xr').value = m.xr_percent;
-            d.querySelector('.xmax').value = m.xmax_percent;
-            d.querySelector('.name').value = m.name;
-          }
-        });
-        // fill materials if loaded
-        const fillSel = () => {
-          sel.innerHTML = '<option value="">—</option>' + materials.map(m => `<option>${m.name}</option>`).join('');
-        };
-        d.fillMaterials = fillSel;
-        return d;
-      };
-      const layers = [];
-      window.addLayer = () => {
-        const idx = layers.length;
-        const el = makeLayerEl(idx);
-        layers.push(el);
-        layersDiv.appendChild(el);
-        if (materials.length) el.fillMaterials();
-      };
-      window.removeLayer = () => {
-        const el = layers.pop();
-        if (el) el.remove();
-      };
-      window.loadMaterials = async () => {
-        try {
-          const res = await fetch('/materials');
-          const js = await res.json();
-          if (js.ok) {
-            materials = js.materials;
-            layers.forEach(el => el.fillMaterials && el.fillMaterials());
-          }
-        } catch (e) { console.warn(e); }
-      };
-      window.runAnalyze = async () => {
-        const layersPayload = layers.map(el => ({
-          name: el.querySelector('.name').value,
-          d: parseFloat(el.querySelector('.d').value || '0'),
-          lambda_: parseFloat(el.querySelector('.lambda').value || '0'),
-          mu: parseFloat(el.querySelector('.mu').value || '0'),
-          rho: parseFloat(el.querySelector('.rho').value || '0'),
-          xr_percent: parseFloat(el.querySelector('.xr').value || '0'),
-          xmax_percent: parseFloat(el.querySelector('.xmax').value || '0'),
-        })).filter(L => L.d > 0 && L.lambda_ > 0);
-        if (!layersPayload.length) { alert('Add at least one valid layer'); return; }
-        const payload = {
-          layers: layersPayload,
-          Rsi: parseFloat(document.getElementById('Rsi').value || '0.13'),
-          Rse: parseFloat(document.getElementById('Rse').value || '0.04'),
-          climate: {
-            theta_i: parseFloat(document.getElementById('theta_i').value || '20'),
-            phi_i: parseFloat(document.getElementById('phi_i').value || '65'),
-            theta_e: parseFloat(document.getElementById('theta_e').value || '5'),
-            phi_e: parseFloat(document.getElementById('phi_e').value || '90'),
-          }
-        };
-        const res = await fetch('/analyze', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload)});
-        const js = await res.json();
-        if (!js.ok) { document.getElementById('results').textContent = 'Error: '+js.error; return; }
-        const r = js.result;
-        document.getElementById('results').textContent = (
-          `U=${r.U.toFixed(4)} W/m²K\n`+
-          `ΣR=${r.R_total.toFixed(4)} m²K/W, q=${r.q.toFixed(3)} W/m²\n`+
-          `Surface risk: ${r.surface.risk ? 'Yes' : 'No'} (θsi=${r.surface.theta_si.toFixed(2)}°C vs θs=${r.surface.theta_s.toFixed(2)}°C)\n`+
-          `Wk_total=${r.Wk_total.toFixed(4)} kg/m² over tk=1440h, Drying capacity=${r.drying_capacity.toFixed(4)} kg/m² → OK=${r.drying_ok ? 'Yes':'No'}`
-        );
-        const zones = r.zones || [];
-        document.getElementById('zones').textContent = zones.length ? zones.map(z => `(${z.start_z.toFixed(3)} → ${z.end_z.toFixed(3)}) maxΔp=${z.max_excess_pa.toFixed(0)} Pa`).join('\n') : '—';
-        drawAssembly(r.layers || [], r.thickness_axis, r.theta_profile, r.zones || [], r.vapor_axis);
-        drawTemp(r.thickness_axis, r.theta_profile);
-        drawVapor(r.vapor_axis, r.p_line, r.p_sat, r.zones || [], r.vapor_axis_final, r.p_final);
-      };
-      function linMap(v, v0,v1, p0,p1){ return p0 + (v - v0) * (p1 - p0) / (v1 - v0 || 1); }
-      function mapZtoX(z, zAxis, xAxis){
-        if (!zAxis || !xAxis || zAxis.length !== xAxis.length) return 0;
-        if (z <= zAxis[0]) return xAxis[0];
-        if (z >= zAxis[zAxis.length-1]) return xAxis[xAxis.length-1];
-        for (let i=1;i<zAxis.length;i++){
-          if (z <= zAxis[i]){
-            const z0=zAxis[i-1], z1=zAxis[i]; const x0=xAxis[i-1], x1=xAxis[i];
-            const t=(z - z0)/((z1 - z0)||1); return x0 + t*(x1 - x0);
-          }
-        }
-        return xAxis[xAxis.length-1];
-      }
-      function drawTemp(x, y){ const c=document.getElementById('chartTemp'); const ctx=c.getContext('2d'); ctx.clearRect(0,0,c.width,c.height); const w=c.width, h=c.height; const pad=40; const xmin=Math.min(...x), xmax=Math.max(...x); const ymin=Math.min(...y), ymax=Math.max(...y); ctx.strokeStyle='#444'; ctx.strokeRect(0,0,w,h); ctx.save(); ctx.translate(pad,pad); const iw=w-2*pad, ih=h-2*pad; ctx.fillStyle='#9ca3af'; ctx.font='12px sans-serif'; ctx.fillText(`${xmin.toFixed(2)} m`,0,ih+16); ctx.fillText(`${xmax.toFixed(2)} m`,iw-60,ih+16); ctx.fillText(`${ymin.toFixed(1)}°C`,-30,ih); ctx.fillText(`${ymax.toFixed(1)}°C`,-30,10); ctx.beginPath(); for(let i=0;i<x.length;i++){ const X=linMap(x[i], xmin,xmax, 0,iw); const Y=linMap(y[i], ymin,ymax, ih,0); if(i===0) ctx.moveTo(X,Y); else ctx.lineTo(X,Y);} ctx.strokeStyle='#60a5fa'; ctx.lineWidth=2; ctx.stroke(); ctx.restore(); }
-      function drawVapor(x, p, ps, zones, xf, pf){ const c=document.getElementById('chartVapor'); const ctx=c.getContext('2d'); ctx.clearRect(0,0,c.width,c.height); const w=c.width,h=c.height; const pad=40; const xmin=Math.min(...x), xmax=Math.max(...x); const all=[...p,...ps]; const ymin=Math.min(...all), ymax=Math.max(...all); ctx.strokeStyle='#444'; ctx.strokeRect(0,0,w,h); ctx.save(); ctx.translate(pad,pad); const iw=w-2*pad, ih=h-2*pad; ctx.fillStyle='#9ca3af'; ctx.font='12px sans-serif'; ctx.fillText(`${xmin.toFixed(2)}`,0,ih+16); ctx.fillText(`${xmax.toFixed(2)}`,iw-30,ih+16); ctx.fillText(`${(ymin/100).toFixed(0)} hPa`,-35,ih); ctx.fillText(`${(ymax/100).toFixed(0)} hPa`,-35,10); const plot = (xs, arr, color) => { ctx.beginPath(); for(let i=0;i<xs.length;i++){ const X=linMap(xs[i], xmin,xmax,0,iw); const Y=linMap(arr[i], ymin,ymax, ih,0); if(i===0) ctx.moveTo(X,Y); else ctx.lineTo(X,Y);} ctx.strokeStyle=color; ctx.lineWidth=2; ctx.stroke(); };
-        if (zones && zones.length){ ctx.fillStyle='rgba(248,113,113,0.15)'; zones.forEach(z => { const X0=linMap(z.start_z, xmin,xmax,0,iw); const X1=linMap(z.end_z, xmin,xmax,0,iw); ctx.fillRect(Math.min(X0,X1),0, Math.abs(X1-X0), ih); }); }
-        plot(x, ps, '#f87171');
-        plot(x, p, '#34d399');
-        if (xf && pf) plot(xf, pf, '#93c5fd');
-        ctx.restore(); }
-      function drawAssembly(layers, xAxis, temps, zones, zAxis){
-        const c=document.getElementById('chartAssembly'); const ctx=c.getContext('2d'); ctx.clearRect(0,0,c.width,c.height); const w=c.width,h=c.height; const pad=40; const xmin=Math.min(...xAxis), xmax=Math.max(...xAxis); const ymin=Math.min(...temps), ymax=Math.max(...temps); ctx.strokeStyle='#444'; ctx.strokeRect(0,0,w,h); ctx.save(); ctx.translate(pad,pad); const iw=w-2*pad, ih=h-2*pad;
-        let x0=xAxis[0]||0; for (let i=1;i<xAxis.length;i++){ const x1=xAxis[i]; const X0=linMap(x0, xmin,xmax,0,iw), X1=linMap(x1, xmin,xmax,0,iw); ctx.fillStyle='rgba(255,255,255,0.05)'; ctx.fillRect(X0,0,X1-X0,ih); ctx.strokeStyle='#1f2937'; ctx.strokeRect(X0,0,X1-X0,ih); const name=layers[i-1]?.name||`L${i}`; ctx.fillStyle='#e5e7eb'; ctx.font='12px sans-serif'; ctx.fillText(`${name} (${(x1-x0).toFixed(3)} m)`, X0+6, 16); x0=x1; }
-        // interfaces
-        ctx.strokeStyle='#374151'; for (let i=0;i<xAxis.length;i++){ const X=linMap(xAxis[i], xmin,xmax,0,iw); ctx.beginPath(); ctx.moveTo(X,0); ctx.lineTo(X,ih); ctx.stroke(); }
-        // zones
-        if (zones && zones.length){ ctx.fillStyle='rgba(248,113,113,0.25)'; zones.forEach(z => { const xA=mapZtoX(z.start_z, zAxis, xAxis); const xB=mapZtoX(z.end_z, zAxis, xAxis); const XA=linMap(xA, xmin,xmax,0,iw), XB=linMap(xB, xmin,xmax,0,iw); ctx.fillRect(Math.min(XA,XB),0, Math.abs(XB-XA), ih); }); }
-        // temperature
-        ctx.beginPath(); for(let i=0;i<xAxis.length;i++){ const X=linMap(xAxis[i], xmin,xmax,0,iw); const Y=linMap(temps[i], ymin,ymax, ih,0); if(i===0) ctx.moveTo(X,Y); else ctx.lineTo(X,Y);} ctx.strokeStyle='#60a5fa'; ctx.lineWidth=2; ctx.stroke(); ctx.restore();
-      }
-      // init with one layer
-      addLayer();
-    }
-  </script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- streamline results page by removing redundant inline script and monospace styling
- rely on external script and CSS for structured metrics and zone tables
- fix quoting bug in condensation report generator

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b03571752c832a8879b1bcb07b01aa